### PR TITLE
feat: dashboard foundation, stores, pages, and project system

### DIFF
--- a/dashboard/src/routes/projects/[id]/channels/+page.server.ts
+++ b/dashboard/src/routes/projects/[id]/channels/+page.server.ts
@@ -1,0 +1,28 @@
+import type { PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = async () => {
+	return {
+		summary: { total: 3, connected: 2, messages: 1284, users: 8 },
+		channels: [
+			{ name: 'Twitch', type: 'twitch', status: 'connected', username: 'ai_playground', viewers: 3, messages: 847, uptime: '4h 12m' },
+			{ name: 'Discord', type: 'discord', status: 'connected', server: 'AI Playground', members: 12, messages: 437, uptime: '2d 8h' },
+			{ name: 'Telegram', type: 'telegram', status: 'disconnected', username: 'aipg_bot', members: 0, messages: 0, uptime: '-' }
+		],
+		dmPolicy: {
+			mode: 'pairing',
+			approvalRequired: true,
+			pairingTimeout: '5m',
+			maxSessions: 3
+		},
+		allowlist: [
+			{ username: 'slo42', platform: 'twitch', role: 'admin', added: '2026-02-15' },
+			{ username: 'family_member', platform: 'twitch', role: 'user', added: '2026-02-20' },
+			{ username: 'dev_helper', platform: 'discord', role: 'moderator', added: '2026-03-01' }
+		],
+		recentMessages: [
+			{ channel: 'Twitch', user: 'slo42', message: 'check the model routing stats', time: '2m ago' },
+			{ channel: 'Discord', user: 'family_member', message: 'can you add eggs to the cart?', time: '8m ago' },
+			{ channel: 'Twitch', user: 'slo42', message: 'spawn a coder agent for the auth fix', time: '15m ago' }
+		]
+	};
+};

--- a/dashboard/src/routes/projects/[id]/channels/+page.svelte
+++ b/dashboard/src/routes/projects/[id]/channels/+page.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+	import MetricCard from '$lib/components/MetricCard.svelte';
+	import type { PageData } from './$types.js';
+
+	let { data }: { data: PageData } = $props();
+
+	const statusDots: Record<string, string> = {
+		connected: 'bg-accent-green',
+		disconnected: 'bg-accent-red',
+		connecting: 'bg-accent-yellow'
+	};
+
+	const typeIcons: Record<string, string> = {
+		twitch: '📺',
+		discord: '💬',
+		telegram: '✈️'
+	};
+</script>
+
+<div class="space-y-6">
+	<!-- Header -->
+	<div class="flex items-center justify-between">
+		<div>
+			<h1 class="text-xl font-bold text-text-primary">Project Channels</h1>
+			<p class="text-sm text-text-secondary mt-1">Messaging channels connected to this project</p>
+		</div>
+		<button class="px-4 py-2 text-sm bg-accent-blue text-white rounded-lg hover:bg-accent-blue/90 transition-colors">
+			+ Connect Channel
+		</button>
+	</div>
+
+	<!-- Summary -->
+	<div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+		<MetricCard label="Total Channels" value={data.summary.total} accent="blue" />
+		<MetricCard label="Connected" value={data.summary.connected} accent="green" />
+		<MetricCard label="Messages" value={data.summary.messages.toLocaleString()} accent="cyan" />
+		<MetricCard label="Active Users" value={data.summary.users} accent="purple" />
+	</div>
+
+	<!-- Channel Cards -->
+	<div>
+		<h2 class="text-xs text-text-secondary uppercase tracking-wider mb-3">Channels</h2>
+		<div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+			{#each data.channels as channel}
+				<div class="bg-bg-secondary border border-border rounded-lg p-4">
+					<div class="flex items-center justify-between mb-3">
+						<div class="flex items-center gap-2">
+							<span class="text-lg">{typeIcons[channel.type]}</span>
+							<span class="text-sm font-bold text-text-primary">{channel.name}</span>
+						</div>
+						<div class="flex items-center gap-1.5">
+							<span class="w-2 h-2 rounded-full {statusDots[channel.status]}"></span>
+							<span class="text-xs text-text-secondary">{channel.status}</span>
+						</div>
+					</div>
+					<div class="space-y-2 text-xs">
+						<div class="flex justify-between">
+							<span class="text-text-secondary">Messages</span>
+							<span class="font-mono text-text-primary">{channel.messages}</span>
+						</div>
+						<div class="flex justify-between">
+							<span class="text-text-secondary">Uptime</span>
+							<span class="font-mono text-text-primary">{channel.uptime}</span>
+						</div>
+					</div>
+					<div class="flex gap-2 mt-3 pt-3 border-t border-border">
+						<button class="flex-1 px-2 py-1.5 text-xs bg-bg-tertiary text-text-secondary rounded hover:text-text-primary transition-colors">
+							Configure
+						</button>
+						{#if channel.status === 'connected'}
+							<button class="px-2 py-1.5 text-xs bg-accent-red/20 text-accent-red rounded hover:bg-accent-red/30 transition-colors">
+								Disconnect
+							</button>
+						{:else}
+							<button class="px-2 py-1.5 text-xs bg-accent-green/20 text-accent-green rounded hover:bg-accent-green/30 transition-colors">
+								Connect
+							</button>
+						{/if}
+					</div>
+				</div>
+			{/each}
+		</div>
+	</div>
+
+	<!-- DM Pairing Policy -->
+	<div>
+		<h2 class="text-xs text-text-secondary uppercase tracking-wider mb-3">DM Pairing Policy</h2>
+		<div class="bg-bg-secondary border border-border rounded-lg p-4">
+			<div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+				<div>
+					<p class="text-xs text-text-secondary uppercase mb-1">Mode</p>
+					<p class="font-mono text-accent-blue">{data.dmPolicy.mode}</p>
+				</div>
+				<div>
+					<p class="text-xs text-text-secondary uppercase mb-1">Approval</p>
+					<p class="font-mono text-text-primary">{data.dmPolicy.approvalRequired ? 'Required' : 'Auto'}</p>
+				</div>
+				<div>
+					<p class="text-xs text-text-secondary uppercase mb-1">Timeout</p>
+					<p class="font-mono text-text-primary">{data.dmPolicy.pairingTimeout}</p>
+				</div>
+				<div>
+					<p class="text-xs text-text-secondary uppercase mb-1">Max Sessions</p>
+					<p class="font-mono text-text-primary">{data.dmPolicy.maxSessions}</p>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<!-- Allowlist -->
+	<div>
+		<h2 class="text-xs text-text-secondary uppercase tracking-wider mb-3">Allowlist</h2>
+		<div class="bg-bg-secondary border border-border rounded-lg overflow-hidden">
+			<div class="grid grid-cols-4 gap-4 px-4 py-2 border-b border-border text-xs text-text-secondary uppercase">
+				<span>Username</span>
+				<span>Platform</span>
+				<span>Role</span>
+				<span>Added</span>
+			</div>
+			{#each data.allowlist as entry}
+				<div class="grid grid-cols-4 gap-4 px-4 py-3 border-b border-border last:border-0">
+					<span class="text-sm font-mono text-text-primary">{entry.username}</span>
+					<span class="text-sm text-text-secondary">{entry.platform}</span>
+					<span class="text-xs px-2 py-0.5 rounded bg-accent-blue/20 text-accent-blue w-fit">{entry.role}</span>
+					<span class="text-sm text-text-secondary">{entry.added}</span>
+				</div>
+			{/each}
+		</div>
+	</div>
+
+	<!-- Recent Messages -->
+	<div>
+		<h2 class="text-xs text-text-secondary uppercase tracking-wider mb-3">Recent Messages</h2>
+		<div class="bg-bg-secondary border border-border rounded-lg overflow-hidden">
+			{#each data.recentMessages as msg}
+				<div class="flex items-center gap-3 px-4 py-3 border-b border-border last:border-0">
+					<span class="text-xs px-2 py-0.5 rounded bg-bg-tertiary text-text-secondary">{msg.channel}</span>
+					<span class="text-sm font-mono text-accent-cyan">{msg.user}</span>
+					<span class="text-sm text-text-primary flex-1">{msg.message}</span>
+					<span class="text-xs text-text-secondary">{msg.time}</span>
+				</div>
+			{/each}
+		</div>
+	</div>
+</div>

--- a/dashboard/src/routes/projects/[id]/models/+page.server.ts
+++ b/dashboard/src/routes/projects/[id]/models/+page.server.ts
@@ -1,0 +1,64 @@
+import type { PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = async () => {
+	return {
+		summary: { total: 4, active: 1, vramUsed: 14.2, vramTotal: 24.0 },
+		routingChain: [
+			{ name: 'GPT-OSS 20B', tier: 'Primary', provider: 'Ollama (local)', latency: '~80ms', cost: '$0', status: 'active' },
+			{ name: 'Claude Sonnet 4.6', tier: 'Escalation', provider: 'Anthropic API', latency: '~2s', cost: '$0.003/1K', status: 'standby' },
+			{ name: 'Claude Haiku 4.5', tier: 'Fallback', provider: 'Anthropic API', latency: '~500ms', cost: '$0.0002/1K', status: 'standby' }
+		],
+		models: [
+			{
+				name: 'gpt-oss:20b',
+				size: '12.4 GB',
+				quantization: 'Q4_K_M',
+				params: '20B (3.6B active)',
+				context: 8192,
+				modified: '2026-02-28',
+				status: 'loaded',
+				vram: 14.2,
+				tokensPerSec: 42.8
+			},
+			{
+				name: 'nomic-embed-text:latest',
+				size: '274 MB',
+				quantization: 'F16',
+				params: '137M',
+				context: 8192,
+				modified: '2026-03-01',
+				status: 'available',
+				vram: 0,
+				tokensPerSec: 0
+			},
+			{
+				name: 'codellama:7b',
+				size: '3.8 GB',
+				quantization: 'Q4_0',
+				params: '7B',
+				context: 16384,
+				modified: '2026-02-15',
+				status: 'available',
+				vram: 0,
+				tokensPerSec: 0
+			},
+			{
+				name: 'llama3.2:3b',
+				size: '2.0 GB',
+				quantization: 'Q4_K_M',
+				params: '3B',
+				context: 131072,
+				modified: '2026-02-20',
+				status: 'available',
+				vram: 0,
+				tokensPerSec: 0
+			}
+		],
+		routingIntelligence: {
+			accuracy: 94.2,
+			localHandled: 87,
+			escalated: 11,
+			fallback: 2
+		}
+	};
+};

--- a/dashboard/src/routes/projects/[id]/models/+page.svelte
+++ b/dashboard/src/routes/projects/[id]/models/+page.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+	import MetricCard from '$lib/components/MetricCard.svelte';
+	import type { PageData } from './$types.js';
+
+	let { data }: { data: PageData } = $props();
+
+	const vramPct = $derived(Math.round((data.summary.vramUsed / data.summary.vramTotal) * 100));
+
+	const statusColors: Record<string, string> = {
+		loaded: 'bg-accent-green',
+		available: 'bg-accent-yellow',
+		error: 'bg-accent-red'
+	};
+
+	const tierColors: Record<string, string> = {
+		Primary: 'bg-accent-green/20 text-accent-green',
+		Escalation: 'bg-accent-blue/20 text-accent-blue',
+		Fallback: 'bg-accent-yellow/20 text-accent-yellow'
+	};
+</script>
+
+<div class="space-y-6">
+	<!-- Header -->
+	<div>
+		<h1 class="text-xl font-bold text-text-primary">Project Models</h1>
+		<p class="text-sm text-text-secondary mt-1">Model routing and VRAM usage for this project</p>
+	</div>
+
+	<!-- Summary -->
+	<div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+		<MetricCard label="Models" value={data.summary.total} accent="blue" />
+		<MetricCard label="Active" value={data.summary.active} accent="green" />
+		<MetricCard label="VRAM Used" value="{data.summary.vramUsed} GB" accent="purple" />
+		<MetricCard label="VRAM Total" value="{data.summary.vramTotal} GB" accent="cyan" />
+	</div>
+
+	<!-- VRAM Gauge -->
+	<div class="bg-bg-secondary border border-border rounded-lg p-4">
+		<div class="flex items-center justify-between mb-2">
+			<span class="text-xs text-text-secondary uppercase tracking-wider">VRAM Usage</span>
+			<span class="text-sm font-mono text-text-primary">{data.summary.vramUsed} / {data.summary.vramTotal} GB ({vramPct}%)</span>
+		</div>
+		<div class="h-3 bg-bg-tertiary rounded-full overflow-hidden">
+			<div
+				class="h-full rounded-full transition-all {vramPct > 90 ? 'bg-accent-red' : vramPct > 70 ? 'bg-accent-yellow' : 'bg-accent-green'}"
+				style="width: {vramPct}%"
+			></div>
+		</div>
+	</div>
+
+	<!-- Routing Chain -->
+	<div>
+		<h2 class="text-xs text-text-secondary uppercase tracking-wider mb-3">Routing Chain</h2>
+		<div class="flex items-center gap-2">
+			{#each data.routingChain as model, i}
+				<div class="flex-1 bg-bg-secondary border border-border rounded-lg p-4">
+					<div class="flex items-center justify-between mb-2">
+						<span class="text-sm font-bold text-text-primary">{model.name}</span>
+						<span class="text-[10px] px-2 py-0.5 rounded {tierColors[model.tier]}">{model.tier}</span>
+					</div>
+					<div class="space-y-1 text-xs">
+						<div class="flex justify-between">
+							<span class="text-text-secondary">Provider</span>
+							<span class="text-text-primary">{model.provider}</span>
+						</div>
+						<div class="flex justify-between">
+							<span class="text-text-secondary">Latency</span>
+							<span class="font-mono text-text-primary">{model.latency}</span>
+						</div>
+						<div class="flex justify-between">
+							<span class="text-text-secondary">Cost</span>
+							<span class="font-mono text-accent-green">{model.cost}</span>
+						</div>
+					</div>
+				</div>
+				{#if i < data.routingChain.length - 1}
+					<span class="text-text-secondary text-lg">→</span>
+				{/if}
+			{/each}
+		</div>
+	</div>
+
+	<!-- Model List -->
+	<div>
+		<h2 class="text-xs text-text-secondary uppercase tracking-wider mb-3">Available Models</h2>
+		<div class="bg-bg-secondary border border-border rounded-lg overflow-hidden">
+			<div class="grid grid-cols-7 gap-4 px-4 py-2 border-b border-border text-xs text-text-secondary uppercase">
+				<span>Model</span>
+				<span>Size</span>
+				<span>Quantization</span>
+				<span>Params</span>
+				<span>Context</span>
+				<span>Status</span>
+				<span>Tokens/s</span>
+			</div>
+			{#each data.models as model}
+				<div class="grid grid-cols-7 gap-4 px-4 py-3 border-b border-border last:border-0 items-center">
+					<span class="text-sm font-mono text-text-primary">{model.name}</span>
+					<span class="text-sm text-text-secondary">{model.size}</span>
+					<span class="text-xs font-mono text-text-secondary">{model.quantization}</span>
+					<span class="text-sm text-text-secondary">{model.params}</span>
+					<span class="text-sm font-mono text-text-secondary">{model.context.toLocaleString()}</span>
+					<div class="flex items-center gap-1.5">
+						<span class="w-2 h-2 rounded-full {statusColors[model.status]}"></span>
+						<span class="text-xs text-text-secondary">{model.status}</span>
+					</div>
+					<span class="text-sm font-mono text-text-primary">{model.tokensPerSec > 0 ? model.tokensPerSec : '-'}</span>
+				</div>
+			{/each}
+		</div>
+	</div>
+
+	<!-- Routing Intelligence -->
+	<div>
+		<h2 class="text-xs text-text-secondary uppercase tracking-wider mb-3">Routing Intelligence</h2>
+		<div class="bg-bg-secondary border border-border rounded-lg p-4">
+			<div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+				<div>
+					<p class="text-xs text-text-secondary uppercase mb-1">Accuracy</p>
+					<p class="text-lg font-mono font-bold text-accent-green">{data.routingIntelligence.accuracy}%</p>
+				</div>
+				<div>
+					<p class="text-xs text-text-secondary uppercase mb-1">Local Handled</p>
+					<p class="text-lg font-mono font-bold text-text-primary">{data.routingIntelligence.localHandled}%</p>
+				</div>
+				<div>
+					<p class="text-xs text-text-secondary uppercase mb-1">Escalated</p>
+					<p class="text-lg font-mono font-bold text-accent-blue">{data.routingIntelligence.escalated}%</p>
+				</div>
+				<div>
+					<p class="text-xs text-text-secondary uppercase mb-1">Fallback</p>
+					<p class="text-lg font-mono font-bold text-accent-yellow">{data.routingIntelligence.fallback}%</p>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
## Summary

Complete dashboard build from Penpot designs — 7 of 8 planned tasks done by a 5-agent swarm.

### What's included

**Foundation (Tasks #1, #2)**
- Tailwind v4 dark theme with 12 DS color tokens as CSS custom properties + utility classes
- Inter + JetBrains Mono fonts via Google Fonts CDN
- shadcn-svelte initialized with 10 base components (button, card, badge, table, input, dialog, tabs, select, separator, tooltip)
- DS colors integrated into shadcn theme variables

**Stores (Task #4)**
- 6 Svelte stores: openclaw (WebSocket), ollama (polling), ruflo (file-read), grocery (HTTP), projects (localStorage), notifications (toast queue)
- All stores typed, with start()/stop() lifecycle, error handling for offline services

**Layout Components (Task #3)**
- Sidebar: 224px, 14 nav items with active state (blue accent bar + 10% bg)
- StatusBar: 48px, 4 service pills with colored dots
- Toast overlay: stacked bottom-right, 4 variants, auto-dismiss
- AlertBanner: full-width dismissible (critical/warning/info)

**Global Pages (Tasks #5, #6)**
- 6 new pages: Sessions, Notifications, Settings, Services (+new dialog), About, Inbox
- 8 existing pages restyled to match Penpot designs with DS tokens
- Layout updated with Sidebar + StatusBar integration

**Project System (Task #7)**
- Project Hub with cards, search, filters
- Create wizard + Import flow
- Project shell layout with project-specific sidebar
- 8 project-scoped pages: Services, About, Settings, Agents, Sessions, Memory, Hooks, Security

**Design References**
- 30 Penpot frame exports as PNG in docs/designs/

### Stats
- 154 files changed, ~7,300 lines added
- Build: 0 errors
- 4 commits across stores → foundation → global pages → restyle + projects

## Test plan
- [ ] `cd dashboard && npm run dev` — all routes accessible at localhost:5173
- [ ] Navigate all 14 global pages via sidebar
- [ ] Navigate project system: /projects → create → /projects/[id] → all scoped pages
- [ ] Verify dark theme with DS colors renders correctly
- [ ] `npm run build` — production build succeeds with adapter-node

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)